### PR TITLE
Docker-compose: Expose db port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       - MARIADB_DATABASE=mydatabase
     volumes:
       - dbdata:/var/lib/mariadb/data/
+    ports:
+      - 3306:3306
 
 volumes:
   dbdata:


### PR DESCRIPTION
Exposed the db port for ease of use with db viewing tools like tableplus