### PR TITLE
Fix port exposure on DB container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     volumes:
       - dbdata:/var/lib/mariadb/data/
     ports:
-      - 3306:3306
+      - 3306
 
 volumes:
   dbdata:


### PR DESCRIPTION
Fixes the following error that I'm receiving when attempting to build the db container with the current port exposure setting (3306:3006):

"Error response from daemon: Ports are not available: exposing port TCP 0.0.0.0:3306 -> 0.0.0.0:0: listen tcp 0.0.0.0:3306: bind: Only one usage of each socket address (protocol/network address/port) is normally permitted."

Hannah, please let me know if this setting still allows you to use your GUI DB manager. 