### PR TITLE
Api edits

### DIFF
--- a/api/resources/blueprints/contribution.py
+++ b/api/resources/blueprints/contribution.py
@@ -33,7 +33,7 @@ class ContributionsByUser(MethodView):
 
   # Ideally in the future we could introduce pagination and return all of a user's contributions
 
-@blp.route("/api/contributions/scores")
+@blp.route("/api/contributions/top-scores")
 class ContributionHighScores(MethodView):
   @blp.response(200, ScoreSchema(many=True))
   def get(self):

--- a/api/resources/blueprints/contribution.py
+++ b/api/resources/blueprints/contribution.py
@@ -15,7 +15,7 @@ class Contributions(MethodView):
   @blp.arguments(ContributionArgSchema, location="query", required=False)
   @blp.response(200, ContributionSchema(many=True))
   def get(self, query_args):
-    """Returns all contributions"""
+    """Returns contributions made using Toolhunt"""
     if query_args:
       limit = query_args["limit"]
       return Task.query.filter(Task.user.is_not(None)).order_by(desc(Task.timestamp)).limit(int(limit))

--- a/api/resources/blueprints/task.py
+++ b/api/resources/blueprints/task.py
@@ -12,4 +12,4 @@ blp = Blueprint("tasks", __name__, description="Fetching and updating Toolhunt t
 class TaskList(MethodView):
   @blp.response(200, TaskSchema(many=True))
   def get(self):
-    return Task.query.filter(Task.user.is_(None))
+    return Task.query.filter(Task.user.is_(None)).limit(10)

--- a/api/resources/schemas.py
+++ b/api/resources/schemas.py
@@ -23,7 +23,7 @@ class TaskSchema(Schema):
 class ContributionSchema(Schema):
   user = fields.Str(required=True)
   timestamp = fields.DateTime(format='%Y-%m-%dT%H:%M:%S%z', required=True)
-  tool_name = fields.Str(required=True)
+  tool = fields.Nested(ToolSchema())
   field_name = fields.Str(required=True)
 
 class ScoreSchema(Schema):

--- a/api/resources/schemas.py
+++ b/api/resources/schemas.py
@@ -26,6 +26,9 @@ class ContributionSchema(Schema):
   tool = fields.Nested(ToolSchema())
   field_name = fields.Str(required=True)
 
+class ContributionArgSchema(Schema):
+  limit = fields.Int(required=False)
+
 class ScoreSchema(Schema):
   user = fields.Str(required=True)
   score = fields.Int(required=True)


### PR DESCRIPTION
This pull request addresses feedback and issues raised by @HWaruguru and @blancadesal 

1. I've added full tool information to the response given by `/api/contributions/`  (Unfortunately I wasn't able to parse out the tool title specifically and I'm not sure why.  The title is available at `tool.title`
2. I changed the name of `api/contributions/scores` to `api/contributions/high-scores`
3. I removed the `api/contributions/latest` endpoint and added ordering-by-date and a query parameter to the base endpoint.

Now, a query to `/api/contributions/?limit={number}` will return the desired number of contributions.  (A query to `/api/contributions/` will return all contributions.)

I will probably add this to other endpoints where we're currently working with a fixed value for `limit`
