### PR TITLE
add toolhunt network to docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     command: /start
     depends_on:
       - db
+    networks:
+      - toolhunt-net
 
   db:
     container_name: mariadb
@@ -26,6 +28,13 @@ services:
       - dbdata:/var/lib/mariadb/data/
     ports:
       - 3306
+    networks:
+      - toolhunt-net
 
+networks:
+  toolhunt-net:
+    name: toolhunt-net
+    driver: bridge
+    
 volumes:
   dbdata:


### PR DESCRIPTION
Given the conversation [here](https://github.com/wikimedia/toolhunt-ui/pull/27), setting up a toolhunt network through docker-compose would be a convenient way to connect the Frontend to the services on the Backend.

This PR adds the ```toolhunt-net``` network to the backend services. This network would be created automatically when docker-compose up is ran.