### PR TITLE
Add date limiting query parameter to /top-scores

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1,16 +1,17 @@
+import datetime
 from flask import jsonify
 from flask.views import MethodView
 from flask_smorest import Blueprint
 from sqlalchemy import desc, text
 from api import db
-from api.schemas import ContributionArgSchema, ContributionSchema, FieldSchema, ScoreSchema, TaskSchema
+from api.schemas import ContributionSchema, ContributionLimitSchema,  FieldSchema, ScoreSchema, ScoreLimitSchema, TaskSchema
 from api.models import Field, Task
 
 contributions = Blueprint("contributions", __name__, description="Get information about contributions made using Toolhunt")
 
 @contributions.route("/api/contributions/")
 class Contributions(MethodView):
-  @contributions.arguments(ContributionArgSchema, location="query", required=False)
+  @contributions.arguments(ContributionLimitSchema, location="query", required=False)
   @contributions.response(200, ContributionSchema(many=True))
   def get(self, query_args):
     """Returns contributions made using Toolhunt"""
@@ -30,16 +31,30 @@ class ContributionsByUser(MethodView):
 
 @contributions.route("/api/contributions/top-scores")
 class ContributionHighScores(MethodView):
+  @contributions.arguments(ScoreLimitSchema, location="query", required=False)
   @contributions.response(200, ScoreSchema(many=True))
-  def get(self):
+  def get(self, query_args):
     """Returns the most prolific Toolhunters and their scores"""
-    query = text("SELECT DISTINCT user, COUNT(*) AS 'score' FROM task WHERE user IS NOT NULL GROUP BY user ORDER BY 2 DESC LIMIT 30")
-    results = db.session.execute(query)
+    if query_args:
+      today = datetime.datetime.now(datetime.timezone.utc)
+      day_count = query_args["since"]
+      end_date = today - datetime.timedelta(days = day_count)
+      print(end_date)
+      scores_query = text("SELECT DISTINCT user, COUNT(*) AS 'score' FROM task WHERE user IS NOT NULL AND timestamp >= :date GROUP BY user ORDER BY 2 DESC LIMIT 30").bindparams(date=end_date)
+      scores = get_scores(scores_query)
+      return jsonify(scores)
+    else: 
+      scores_query = text("SELECT DISTINCT user, COUNT(*) AS 'score' FROM task WHERE user IS NOT NULL GROUP BY user ORDER BY 2 DESC LIMIT 30")
+      scores = get_scores(scores_query)
+      return jsonify(scores)
+
+def get_scores(scores_query):
+    results = db.session.execute(scores_query)
     scores = []
     for row in results:
       result = {"user": row[0], "score": row[1]}
       scores.append(result)
-    return jsonify(scores)
+    return scores
   
 
 fields = Blueprint("fields", __name__, description="Retrieving information about annotations fields")

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -27,9 +27,12 @@ class ContributionSchema(Schema):
   tool = fields.Nested(ToolSchema())
   field_name = fields.Str(required=True)
 
-class ContributionArgSchema(Schema):
+class ContributionLimitSchema(Schema):
   limit = fields.Int(required=False)
 
 class ScoreSchema(Schema):
   user = fields.Str(required=True)
   score = fields.Int(required=True)
+
+class ScoreLimitSchema(Schema):
+  since = fields.Int(required=False)


### PR DESCRIPTION
As requested by @HWaruguru, a GET request to /api/contributions/top-scores?fromPast={number} will return the score results from the past {number} days.

The parameter is optional; a GET request to /api/contributions/top-scores will return the score aggregates based on all contributions in the database.

In the future I could expand this to accept two parameters; right now it will always start from the current date.