### PR TITLE
Add /api/user endpoint

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -6,7 +6,7 @@ from flask_sqlalchemy import SQLAlchemy
 db = SQLAlchemy()
 migrate = Migrate()
 
-from api.routes import fields, contributions, tasks
+from api.routes import fields, contributions, tasks, user
 from api.config import config
 
 def create_app(config_name=None):
@@ -21,6 +21,7 @@ def create_app(config_name=None):
   api.register_blueprint(tasks)
   api.register_blueprint(contributions)
   api.register_blueprint(fields)
+  api.register_blueprint(user)
   migrate.init_app(app, db)
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -135,8 +135,9 @@ def build_request(task_data):
 
 def get_current_user():
   """Get the username of currently logged-in user."""
-  from app import oauth
   try:
+    # Importing the oauth early results in an error
+    from app import oauth
     resp = oauth.toolhub.get("user/", token=flask.session["token"])
     resp.raise_for_status()
     profile = resp.json()
@@ -153,3 +154,21 @@ def put_to_toolhub(tool, data):
   response = requests.put(url, data=data, headers=header)
   r = response.status_code
   return r
+
+user = Blueprint("user", __name__, description="Get information about the currently logged-in user.")
+
+@user.route("/api/user")
+class CurrentUser(MethodView):
+  @tasks.response(200)
+  def get(self):
+    """Get the username of currently logged-in user."""
+    try:
+      # Importing the oauth early results in an error
+      from app import oauth
+      resp = oauth.toolhub.get("user/", token=flask.session["token"])
+      resp.raise_for_status()
+      profile = resp.json()
+      username = profile["username"]
+      return username
+    except:
+      return "No user is currently logged in."

--- a/api/routes.py
+++ b/api/routes.py
@@ -1,7 +1,6 @@
 import flask
 import datetime
 import requests
-from flask import jsonify
 from flask.views import MethodView
 from flask_smorest import Blueprint, abort
 from sqlalchemy import desc, text
@@ -44,11 +43,11 @@ class ContributionHighScores(MethodView):
       print(end_date)
       scores_query = text("SELECT DISTINCT user, COUNT(*) AS 'score' FROM task WHERE user IS NOT NULL AND timestamp >= :date GROUP BY user ORDER BY 2 DESC LIMIT 30").bindparams(date=end_date)
       scores = get_scores(scores_query)
-      return jsonify(scores)
+      return scores
     else: 
       scores_query = text("SELECT DISTINCT user, COUNT(*) AS 'score' FROM task WHERE user IS NOT NULL GROUP BY user ORDER BY 2 DESC LIMIT 30")
       scores = get_scores(scores_query)
-      return jsonify(scores)
+      return scores
 
 def get_scores(scores_query):
     """Insert score data into a list of dicts and return."""
@@ -178,6 +177,6 @@ class CurrentUser(MethodView):
     response = get_current_user()
     if type(response) == str:
       username = {"username": response}
-      return jsonify(username)
+      return username
     else:
-      return jsonify(response)
+      return response

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -41,3 +41,6 @@ class ScoreSchema(Schema):
 
 class ScoreLimitSchema(Schema):
   since = fields.Int(required=False)
+
+class UserSchema(Schema):
+  username = fields.Str(required=True)


### PR DESCRIPTION
As @Damilare1's request, I've added the `/api/user` endpoint, which will return either
```
{
"username": <username>
}
```
or an error if no user is currently logged in.
```
{
  "code": 401,
  "message": "No user is currently logged in.",
  "status": "Unauthorized"
}
```

In future we could expand this endpoint to return more information about the user.