### PR TITLE
Switch Swagger-ui asset origin to Toolforge CDNjs

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -15,7 +15,7 @@ class BaseConfig:
   OPENAPI_VERSION = "3.0.3"
   OPENAPI_URL_PREFIX = "/"
   OPENAPI_SWAGGER_UI_PATH = "/api/documentation"
-  OPENAPI_SWAGGER_UI_URL = "https://cdn.jsdelivr.net/npm/swagger-ui-dist/"
+  OPENAPI_SWAGGER_UI_URL = "https://tools-static.wmflabs.org/cdnjs/ajax/libs/swagger-ui/4.15.5/"
   PROPAGATE_EXCEPTIONS = True
 
   # OAuth


### PR DESCRIPTION
We don't want to make Toolforge unhappy.
This addresses T330260