### PR TITLE
Pass username to Celery tasks

### DIFF
--- a/api/async_tasks.py
+++ b/api/async_tasks.py
@@ -24,7 +24,7 @@ def make_put_request(self, tool_name, submission_data, token):
 
 
 @shared_task()
-def process_result(result, task_id, edited_field, submitted_value):
+def process_result(result, task_id, edited_field, submitted_value, username):
     # If the result contains a "code" field, it failed.
     # But this should never happen, as long as our validation is done correctly.
     if "code" in result:
@@ -44,10 +44,6 @@ def process_result(result, task_id, edited_field, submitted_value):
             # If so, we update our database
             task = Task.query.get(task_id)
             tool_name = task.tool_name
-            # username = get_current_user()
-            # testing with hard coded user because I was getting logged out in between the
-            # execution of the put request task, and this task
-            username = "dummyuser"
             task.user = username
             task.timestamp = datetime.datetime.now(datetime.timezone.utc)
             db.session.add(task)

--- a/api/routes.py
+++ b/api/routes.py
@@ -248,8 +248,8 @@ class TaskById(MethodView):
                 tool_name = form_data["tool"]
                 submission_data = build_request(form_data)
                 token = flask.session["token"]["access_token"]
-                chain(make_put_request.s(tool_name, submission_data, token) | process_result.s(task.id, form_data["field"], form_data["value"]))()
-                return "Task sent."
+                chain(make_put_request.s(tool_name, submission_data, token) | process_result.s(task.id, form_data["field"], form_data["value"], form_data["user"]))()
+                return "Submission sent.  Thank you for your contribution!"
             else:
                 abort(401, message="User must be logged in to update a tool.")
         else:

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -29,6 +29,7 @@ class TaskCompleteSchema(Schema):
     tool = fields.Str(required=True)
     field = fields.Str(required=True)
     value = fields.Str(required=True)
+    user = fields.Str(required=True)
 
 
 class ContributionSchema(Schema):


### PR DESCRIPTION
This is reliant upon https://github.com/wikimedia/toolhunt-ui/pull/39, where I add the "user" to the PUT request payload.