### PR TITLE
Add .yaml file for the staging tool

### DIFF
--- a/deployment-staging.yaml
+++ b/deployment-staging.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: toolhunt-api-staging.worker
+  namespace: tool-toolhunt-api-staging
+  labels:
+    name: toolhunt-api-staging.worker
+    # The toolforge=tool label will cause $HOME and other paths to be mounted from Toolforge
+    toolforge: tool
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: toolhunt-api-staging.worker
+      toolforge: tool
+  template:
+    metadata:
+      labels:
+        name: toolhunt-api-staging.worker
+        toolforge: tool
+    spec:
+      containers:
+        - name: bot
+          image: docker-registry.tools.wmflabs.org/toolforge-python39-sssd-base:latest
+          command:
+            [
+              "/data/project/toolhunt-api-staging/www/python/src/compose/flask/celery/worker/toolforge-start.sh",
+            ]
+          workingDir: /data/project/toolhunt-api-staging/www/python/src/
+          env:
+            - name: HOME
+              value: /data/project/toolhunt-api-staging
+          imagePullPolicy: Always


### PR DESCRIPTION
This saves me the pain of having to edit deployment.yaml after every update to toolhunt-api-staging.  Although I shouldn't have to restart the Celery worker very often (if ever), I know I'm going to forget to keep the file updated.