### PR TITLE
Add new routes to support search bar

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -37,12 +37,13 @@ def create_app():
             client_kwargs=None,
         )
         # register blueprints
-        from api.routes import contributions, fields, metrics, tasks, user  # noqa
+        from api.routes import contributions, fields, metrics, tasks, tools, user  # noqa
 
         api.register_blueprint(tasks)
         api.register_blueprint(contributions)
         api.register_blueprint(fields)
         api.register_blueprint(metrics)
+        api.register_blueprint(tools)
         api.register_blueprint(user)
         migrate.init_app(app, db)
 

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -37,7 +37,14 @@ def create_app():
             client_kwargs=None,
         )
         # register blueprints
-        from api.routes import contributions, fields, metrics, tasks, tools, user  # noqa
+        from api.routes import (  # noqa
+            contributions,
+            fields,
+            metrics,
+            tasks,
+            tools,
+            user,
+        )
 
         api.register_blueprint(tasks)
         api.register_blueprint(contributions)

--- a/api/routes.py
+++ b/api/routes.py
@@ -276,6 +276,32 @@ class TaskById(MethodView):
             abort(400, message="The data given doesn't match the task specifications.")
 
 
+tools = Blueprint(
+    "tools", __name__, description="Get information about the tools in our database."
+)
+
+
+@tools.route("/api/tools/names")
+class ToolNames(MethodView):
+    @tools.response(200)
+    def get(self):
+        """Get the human-readable titles of all tools, and their Toolhub names."""
+        try: 
+            # This will work, as long as there are no tools with the 
+            # title "allTitles", and no duplicate names
+            # Seems improbable, but not impossible
+            response = db.session.execute(text("SELECT name, title FROM tool")).all()
+            titleCollection = {
+                "allTitles": []
+            }
+            for tool in response:
+                titleCollection[tool.title.decode()] = tool.name.decode()
+                titleCollection["allTitles"].append(tool.title.decode())
+            return titleCollection
+        except exc.OperationalError as err:
+            print(err)
+            abort(503, message="Database connection failed.  Please try again.")
+
 user = Blueprint(
     "user", __name__, description="Get information about the currently logged-in user."
 )
@@ -283,7 +309,7 @@ user = Blueprint(
 
 @user.route("/api/user")
 class CurrentUser(MethodView):
-    @tasks.response(200, UserSchema)
+    @user.response(200, UserSchema)
     def get(self):
         """Get the username of the currently logged-in user."""
         response = get_current_user()

--- a/api/routes.py
+++ b/api/routes.py
@@ -226,20 +226,22 @@ class TaskList(MethodView):
         "Get ten incomplete tasks."
         return Task.query.order_by(func.random()).limit(10)
 
+
 @tasks.route("/api/tasks/tool/<string:tool_name>")
 class TaskByTool(MethodView):
     @tasks.response(200, TaskSchema(many=True))
     def get(self, tool_name):
         "Get a set of tasks for a given tool."
-        try:   
+        try:
             # If tool_test fails then the tool name is bad and we can stop.
             tool_test = Tool.query.get_or_404(tool_name)
-            if (tool_test):
-                tasks = Task.query.filter_by(tool_name = tool_name)
+            if tool_test:
+                tasks = Task.query.filter_by(tool_name=tool_name)
                 return tasks
         except exc.OperationalError as err:
             print(err)
             abort(503, message="Database connection failed.  Please try again.")
+
 
 @tasks.route("/api/tasks/type/<string:task_type>")
 class TaskByType(MethodView):
@@ -247,12 +249,13 @@ class TaskByType(MethodView):
     def get(self, task_type):
         "Get a set of tasks of a selected type."
         # Could expand to select multiple task types
-        try:   
-            tasks = Task.query.filter_by(field_name = task_type).limit(10)
+        try:
+            tasks = Task.query.filter_by(field_name=task_type).limit(10)
             return tasks
         except exc.OperationalError as err:
             print(err)
             abort(503, message="Database connection failed.  Please try again.")
+
 
 @tasks.route("/api/tasks/<string:task_id>")
 class TaskById(MethodView):
@@ -299,14 +302,12 @@ class ToolNames(MethodView):
     @tools.response(200)
     def get(self):
         """Get the human-readable titles of all tools, and their Toolhub names."""
-        try: 
-            # This will work, as long as there are no tools with the 
+        try:
+            # This will work, as long as there are no tools with the
             # title "allTitles", and no duplicate names
             # Seems improbable, but not impossible
             response = db.session.execute(text("SELECT name, title FROM tool")).all()
-            titleCollection = {
-                "allTitles": []
-            }
+            titleCollection = {"allTitles": []}
             for tool in response:
                 titleCollection[tool.title.decode()] = tool.name.decode()
                 titleCollection["allTitles"].append(tool.title.decode())
@@ -314,6 +315,7 @@ class ToolNames(MethodView):
         except exc.OperationalError as err:
             print(err)
             abort(503, message="Database connection failed.  Please try again.")
+
 
 user = Blueprint(
     "user", __name__, description="Get information about the currently logged-in user."

--- a/api/routes.py
+++ b/api/routes.py
@@ -241,6 +241,19 @@ class TaskByTool(MethodView):
             print(err)
             abort(503, message="Database connection failed.  Please try again.")
 
+@tasks.route("/api/tasks/type/<string:task_type>")
+class TaskByType(MethodView):
+    @tasks.response(200, TaskSchema(many=True))
+    def get(self, task_type):
+        "Get a set of tasks of a selected type."
+        # Could expand to select multiple task types
+        try:   
+            tasks = Task.query.filter_by(field_name = task_type).limit(10)
+            return tasks
+        except exc.OperationalError as err:
+            print(err)
+            abort(503, message="Database connection failed.  Please try again.")
+
 @tasks.route("/api/tasks/<string:task_id>")
 class TaskById(MethodView):
     @tasks.response(200, TaskSchema)


### PR DESCRIPTION
We now have a working search bar, and a route that I can use to filter tasks by field name, once I decide how to add it to the front end.

This task addresses [T332910](https://phabricator.wikimedia.org/T332910)